### PR TITLE
fix caching of build time dependencies

### DIFF
--- a/run/action.yaml
+++ b/run/action.yaml
@@ -116,7 +116,7 @@ runs:
     - name: ${{ fromJSON(env.JSON).action }} ${{ fromJSON(env.JSON).name }}
       if: fromJSON(env.JSON).action != 'build'
       env:
-        BUILT: ${{ steps.build.outputs.uncached }}
+        BUILT: ${{ steps.build.outputs.built }}
       run: |
         ${{ github.action_path }}/run.sh
       shell: bash

--- a/run/build.sh
+++ b/run/build.sh
@@ -4,22 +4,26 @@ set -e
 
 DRVS=$(jq -r '.|to_entries[]|select(.key|test("Drv$"))|select(.value|.!=null)|.value' <<< "$JSON")
 declare -r DRVS
-declare -a unbuilt
+declare -a unbuilt uncached
 
 function calc_uncached() {
   echo "::group::Calculate Uncached Builds"
 
+   #shellcheck disable=SC2086
+   mapfile -s 1 -t uncached < <(nix-store --realise --dry-run $DRVS 2>&1 | sed '/paths will be fetched/,$ d')
+
   #shellcheck disable=SC2068
   for drv in ${DRVS[@]}; do
     # if the line grepped for doesn't show in the output, then there is nothing to build that isn't already cached
-    if nix-store --realise "$drv" --dry-run 2>&1 | grep --silent 'derivations will be built:$'; then
+    if nix-store --realise "$drv" --dry-run 2>&1 | grep --silent 'will be built:$'; then
       unbuilt+=("$drv")
     fi
   done
 
   echo "::debug::uncached paths: ${unbuilt[*]}"
 
-  echo "uncached=${unbuilt[*]}" >> "$GITHUB_OUTPUT"
+  echo "built=${unbuilt[*]}" >> "$GITHUB_OUTPUT"
+  echo "uncached=${uncached[*]}" >> "$GITHUB_OUTPUT"
 
   echo "::endgroup::"
 }

--- a/run/cache.sh
+++ b/run/cache.sh
@@ -16,7 +16,7 @@ function upload() {
   fi
 
   #shellcheck disable=SC2086
-  nix copy --from "$BUILDER" --to "$CACHE" $UNCACHED
+  echo $UNCACHED | xargs nix copy --from "$BUILDER" --to "$CACHE"
 
   echo "::endgroup::"
 }


### PR DESCRIPTION
462c4ca7974448b6b7fc6011db4b452afb25af55 accidentally broke caching of uncached build time dependencies. However, we still don't want to invoke `nix-build` more than once for performance reasons.

The solution is to use the previous method for the caching step combined with `xargs`, which ensures the OS arg limit is never exceeded by default, while maintain the new method for the build step.