### PR TITLE
run: only use target derivations

### DIFF
--- a/run/build.sh
+++ b/run/build.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-DRVS=$(jq -r '.|to_entries[]|select(.key|test("Drv$"))|select(.value|.!=null)|.value' <<< "$JSON")
-declare -r DRVS
+target=$(jq -er '.targetDrv' <<< "$JSON")
+declare -r target
 declare -a uncached
 
 function calc_uncached() {
   echo "::group::Calculate Uncached Builds"
 
   #shellcheck disable=SC2086
-  mapfile -t uncached < <(nix-store --realise --dry-run $DRVS 2>&1 1>/dev/null | sed '/paths will be fetched/,$ d' | grep '/nix/store/.*\.drv$')
+  mapfile -t uncached < <(nix-store --realise --dry-run $target 2>&1 1>/dev/null | sed '/paths will be fetched/,$ d' | grep '/nix/store/.*\.drv$')
 
   echo "::debug::uncached paths: ${uncached[*]}"
 
@@ -26,9 +26,7 @@ function build() {
 
   if [[ -n ${uncached[*]} ]]; then
     #shellcheck disable=SC2086
-    echo "::debug::these paths will be built: $DRVS"
-
-    echo "${uncached[@]}" | xargs -- nix-build --eval-store auto --store "$BUILDER"
+    nix-build --eval-store auto --store "$BUILDER" "$target"
   else
     echo "Everything already cached, nothing to build."
   fi

--- a/run/build.sh
+++ b/run/build.sh
@@ -12,6 +12,10 @@ function calc_uncached() {
   #shellcheck disable=SC2086
   mapfile -t uncached < <(nix-store --realise --dry-run $target 2>&1 1>/dev/null | sed '/paths will be fetched/,$ d' | grep '/nix/store/.*\.drv$')
 
+  # filter out builds that are always run locally, and thus, not cached
+  #shellcheck disable=SC2068
+  mapfile -t uncached < <(nix show-derivation ${uncached[@]} | jq -r '.| to_entries[] | select(.value|.env.preferLocalBuild != "1") | .key')
+
   echo "::debug::uncached paths: ${uncached[*]}"
 
   echo "uncached=${uncached[*]}" >> "$GITHUB_OUTPUT"

--- a/run/build.sh
+++ b/run/build.sh
@@ -9,12 +9,14 @@ declare -a uncached
 function calc_uncached() {
   echo "::group::Calculate Uncached Builds"
 
+  set -x
   #shellcheck disable=SC2086
   mapfile -t uncached < <(nix-store --realise --dry-run $target 2>&1 1>/dev/null | sed '/paths will be fetched/,$ d' | grep '/nix/store/.*\.drv$')
 
   # filter out builds that are always run locally, and thus, not cached
   #shellcheck disable=SC2068
   mapfile -t uncached < <(nix show-derivation ${uncached[@]} | jq -r '.| to_entries[] | select(.value|.env.preferLocalBuild != "1") | .key')
+  set +x
 
   echo "::debug::uncached paths: ${uncached[*]}"
 

--- a/run/run.sh
+++ b/run/run.sh
@@ -3,22 +3,42 @@
 set -e
 shopt -s lastpipe
 
+function check_exec() {
+  path="$1"
+  shift
+  find -L "$path" -executable -type f "$@" 2>/dev/null
+}
+
 function run() {
   local action drv
 
-  jq -r '.action + " " + .targetDrv' <<< "$JSON" | read -r action drv
+  jq -r '.action + " " + .name + " " + .targetDrv' <<< "$JSON" | read -r action name drv
 
-  echo "::group::Running $action"
+  echo "::group::$action $name"
 
-  if [[ -n $BUILT ]]; then
+  if [[ -z $BUILT ]]; then
     # should be fetched, since we have already checked cache status in build step
     nix-build "$drv" --no-out-link
   elif [[ $BUILDER != auto ]]; then
     nix copy --from "$BUILDER" "$drv"
   fi
 
-  # run the action script
-  eval "$(nix show-derivation "$drv" | jq -r '.[].outputs.out.path')"
+  out="$(nix show-derivation "$drv" | jq -r '.[].outputs.out.path')"
+  # if the outpath is a script execute it
+  if [[ -n $(check_exec "$out" -maxdepth 0) ]]; then
+    "$out"
+  # else check for a script with the same name
+  elif [[ -n $(check_exec "$out/bin/$name") ]]; then
+    "$out/bin/$name"
+  else
+    # find first executable file in $out/bin
+    executable=$(check_exec "$out/bin" | head -1)
+    if [[ -n $executable ]]; then
+      "$executable"
+    else
+      echo "Target is not executable, nothing to run."
+    fi
+  fi
 
   echo "::endgroup::"
 }

--- a/run/run.sh
+++ b/run/run.sh
@@ -6,11 +6,11 @@ shopt -s lastpipe
 function run() {
   local action drv
 
-  jq -r '.action + " " + .actionDrv' <<< "$JSON" | read -r action drv
+  jq -r '.action + " " + .targetDrv' <<< "$JSON" | read -r action drv
 
   echo "::group::Running $action"
 
-  if ! [[ $BUILT =~ $drv ]]; then
+  if [[ -n $BUILT ]]; then
     # should be fetched, since we have already checked cache status in build step
     nix-build "$drv" --no-out-link
   elif [[ $BUILDER != auto ]]; then


### PR DESCRIPTION
The actionDrv is never more than a thin wrapper around Nix to call a flake path represented by the targetDrv. There is no reason to reintroduce Nix evaluation by calling `nix run` directly when we already know its target in advance.