### PR TITLE
run: fix a bad assumption for actions

### DIFF
--- a/run/build.sh
+++ b/run/build.sh
@@ -14,9 +14,12 @@ function calc_uncached() {
   mapfile -t uncached < <(nix-store --realise --dry-run $target 2>&1 1>/dev/null | sed '/paths will be fetched/,$ d' | grep '/nix/store/.*\.drv$')
 
   # filter out builds that are always run locally, and thus, not cached
-  #shellcheck disable=SC2068
-  mapfile -t uncached < <(nix show-derivation ${uncached[@]} | jq -r '.| to_entries[] | select(.value|.env.preferLocalBuild != "1") | .key')
+  if [[ -n ${uncached[*]} ]]; then
+    #shellcheck disable=SC2068
+    mapfile -t uncached < <(nix show-derivation ${uncached[@]} | jq -r '.| to_entries[] | select(.value|.env.preferLocalBuild != "1") | .key')
+  fi
   set +x
+
 
   echo "::debug::uncached paths: ${uncached[*]}"
 

--- a/run/run.sh
+++ b/run/run.sh
@@ -12,7 +12,7 @@ function check_exec() {
 function run() {
   local action drv
 
-  jq -r '.action + " " + .name + " " + .targetDrv' <<< "$JSON" | read -r action name drv
+  jq -r '.action + " " + .name + " " + .actionDrv' <<< "$JSON" | read -r action name drv
 
   echo "::group::$action $name"
 
@@ -24,21 +24,7 @@ function run() {
   fi
 
   out="$(nix show-derivation "$drv" | jq -r '.[].outputs.out.path')"
-  # if the outpath is a script execute it
-  if [[ -n $(check_exec "$out" -maxdepth 0) ]]; then
-    "$out"
-  # else check for a script with the same name
-  elif [[ -n $(check_exec "$out/bin/$name") ]]; then
-    "$out/bin/$name"
-  else
-    # find first executable file in $out/bin
-    executable=$(check_exec "$out/bin" | head -1)
-    if [[ -n $executable ]]; then
-      "$executable"
-    else
-      echo "Target is not executable, nothing to run."
-    fi
-  fi
+  "$out"
 
   echo "::endgroup::"
 }


### PR DESCRIPTION
In order to attempt to ensure that a nix evaluation never occurs on a job runner, an assumption was made that action derivations would always simply invoke their target derivations. This is not actually the case so we have to just build and call the `actionDrv` to ensure the proper action is run.

Unfortunately this means that the action may call Nix and may induce evaluation, but in practice no jobs seem to introduce a significant eval overhead as of now.

However, we may want to explore a solution upstream where we track any derivations the action may invoke, so we have a triplet of:
- actionDrv
- targetDrv
- actionTargetDrv

Which would then allows us to ensure we don't introduce another, potentially expensive, evaluation.