### PR TITLE
feat: implement efficient remote store support with better logging UX

### DIFF
--- a/run/action.yaml
+++ b/run/action.yaml
@@ -19,6 +19,17 @@ inputs:
       host. Access to that discovery host with alias 'discovery' must be
       provided indendently via SSH configuraiton.
 
+  remoteStore:
+    required: false
+    default: false
+    description: |
+      When set, builds are made on this remote store, e.g. inside a build server farm.
+
+      Can be set to any of the values available for the `--store` nix command line flag.
+      For example, to connect to nixbuild.net, simply set it to `ssh-ng://eu.nixbuild.net` \*.
+
+      \* If using nixbuild.net, in particular, also make sure to configure their `nixbuild-action`.
+
 runs:
   using: "composite"
   steps:
@@ -49,6 +60,12 @@ runs:
         key: drv-pack-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
         fail-on-cache-miss: true
 
+    - name: Setup fake tty
+      shell: bash
+      run: |
+        echo "TERM=xterm-256color" >> $GITHUB_ENV
+        nix --quiet profile install nixpkgs#faketty
+
     - name: Execute on ${{ env.target }}
       id: build
       run: ${{ github.action_path }}/execute.sh
@@ -56,6 +73,8 @@ runs:
       env:
         EVALSTORE_IMPORT: ${{ runner.temp }}/eval-store
         DRV_IMPORT_FROM_DISCOVERY: ${{ inputs.ffBuildInstructions }}
+        REMOTE_STORE: ${{ inputs.remoteStore }}
+
         # prj-spec <https://github.com/numtide/prj-spec>
         PRJ_ROOT: ${{ github.workspace }}
         PRJ_DATA_HOME: ${{ runner.temp }}/.data

--- a/run/execute.sh
+++ b/run/execute.sh
@@ -17,11 +17,64 @@ fi
 echo "::group::🏗️ build //$cell/$block/$target"
 
 #shellcheck disable=SC2086
-command nix-build --eval-store auto "$actionDrv"
+build_args=(
+  "--no-link"
+  "--print-build-logs"
+  "--log-format" "raw-with-logs"
+  "--eval-store" "auto"
+)
+
+if [[ "$REMOTE_STORE" != "false" ]]; then
+  build_args+=(
+    "--builders" "''"
+    "--store" "$REMOTE_STORE"
+  )
+fi
+
+# Note about: sed $'s/\r\033\[0m\033\[K//g'
+#   works around https://discourse.nixos.org/t/nix-with-faketty/31042
+start=`date +%s`
+faketty nix build "${build_args[@]}" "$actionDrv^out" \
+  1> /dev/null \
+  2> >(sed --unbuffered $'
+    s/\r\033\[0m\033\[K//g
+
+    # match lines starting with copying
+    /copying path .*/ {
+      # write them to ./copylogs
+      w ./copylogs
+      # delete them from the stream
+      d
+    }
+  ' >&2)
+
+echo "Copied $(cat ./copylogs | sed '/copying 0 .*/d' | wc -l) paths during the build."
+end=`date +%s`
+echo -e "\033[0;32mBuilt action closure in $((end-start)) seconds\033[0m"
 
 echo "::endgroup::"
 
 shopt -s lastpipe
+
+out="$(nix derivation show $actionDrv^out | jq -r '.[].outputs.out.path')"
+if [[ "$REMOTE_STORE" != "false" ]] && [[ ! -e "$out" ]]; then
+  echo "::group::🐟 fetch $action closure (from $REMOTE_STORE)"
+  start=`date +%s`
+  nix copy --from "$REMOTE_STORE" "$out" 1> /dev/null 2> >(sed --unbuffered "
+
+    # delete some lines that dont make sense
+    /^$/d
+    /don't know how to.*/d
+    \%^\s\s/nix/store/.*%d
+
+    # be less noisy - extract store path only
+    s/copying path '//g;s/'.*//g;
+
+  " >&2)
+  end=`date +%s`
+  echo -e "\033[0;32mFetched action closure in $((end-start)) seconds.\033[0m"
+  echo "::endgroup::"
+fi
 
 #shellcheck disable=SC2154
 if [[ "$action" != "build" ]]; then
@@ -29,10 +82,17 @@ if [[ "$action" != "build" ]]; then
   #shellcheck disable=SC2154
   echo "::group::🏍️️ $action //$cell/$block/$target"
   {
+    
+    echo -e "\033[1;32m//$cell/$block/$target:$action\033[0m"
+    echo -e "\033[1;32m.  $out\033[0m"
+
+    start=`date +%s`
     # this trick preserves set -e & set -o pipefail from above
     #shellcheck disable=SC1090
-    function _run() { . ./result; }
+    function _run() { . "$out"; }
     _run
+    end=`date +%s`
+    echo -e "\033[0;32mRan action in $((end-start)) seconds.\033[0m"
   }
   echo "::endgroup::"
 fi


### PR DESCRIPTION
# Context

One of the bigger challenges with Nix in CI is the unfriendly log output.

# Solution

This PR implements three things:

- run nix through faketty so that colors are output wherever possible
- add support for remote store builds
- improve the runner staging and logs; add cycle time measure
