### PR TITLE
fix: clean up ssh agent after ourselves

### DIFF
--- a/setup-discovery-ssh/action.yaml
+++ b/setup-discovery-ssh/action.yaml
@@ -37,3 +37,8 @@ runs:
         DISCOVERY_USER_NAME: ${{ inputs.user_name }}
         DISCOVERY_SSH_KNOWN_HOSTS_ENTRY: ${{ inputs.ssh_known_hosts_entry }}
         DISCOVERY_SSH_KEY: ${{ inputs.ssh_key }}
+
+runs:
+  using: 'node16'
+  main: 'setup.js'
+  post: 'cleanup.js'

--- a/setup-discovery-ssh/cleanup.js
+++ b/setup-discovery-ssh/cleanup.js
@@ -1,0 +1,11 @@
+const core = require("@actions/core");
+
+async function run() {
+  try {
+    process.kill(process.env.STATE_SSH_AGENT_PID);
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+run();

--- a/setup-discovery-ssh/setup.js
+++ b/setup-discovery-ssh/setup.js
@@ -1,0 +1,23 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import * as core from "@actions/core";
+import * as exec from "@actions/exec";
+
+async function run() {
+  try {
+    core.exportVariable("DISCOVERY_USER_NAME", core.getInput("user_name"));
+    core.exportVariable(
+      "DISCOVERY_SSH_KNOWN_HOSTS_ENTRY",
+      core.getInput("ssh_known_hosts_entry")
+    );
+    core.exportVariable("DISCOVERY_SSH_KEY", core.getInput("ssh_key"));
+    // await exec.exec(path.resolve(__dirname, "setup.sh"), []);
+    await exec.exec(path.resolve(__dirname, "setup.sh"));
+  } catch (error) {
+    core.setFailed(error.message);
+  }
+}
+
+run();

--- a/setup-discovery-ssh/setup.sh
+++ b/setup-discovery-ssh/setup.sh
@@ -31,6 +31,8 @@ if ssh-keygen -y -f "$ssh_key_file" &>/dev/null; then
   ssh-add -q "$ssh_key_file" && rm "$ssh_key_file"
   # Auth agent socket to ssh config
   echo "IdentityAgent $SSH_AUTH_SOCK" >> "$SSH_CONFIG_FILE"
+  # Save pid to cleanup in post step
+  echo "SSH_AGENT_PID=$SSH_AGENT_PID" >> "$GITHUB_STATE"
 else
   echo -e >&2 \
 "Your SSH key is not a valid OpenSSH private key\n"\


### PR DESCRIPTION
# Context

The ssh connection to a discovery host leaves a dangling ssh agent.
If the workflow runner itself runs on a persistent runner, that process might just accumulate.

# Solution

Clean up after ourselves. Unfortunately, only js actions allow to trigger a post action which is why a slight refactor needed to be done to wrap the bash action inside a js action.
