### PR TITLE
fix!: mark jobs as skipped instead of removing them

### DIFF
--- a/discover/eval.sh
+++ b/discover/eval.sh
@@ -59,6 +59,7 @@ function provision() {
           echo "$action"
         else
           echo >&2 " - drop it."
+          jq -c '. + {skipped: true}' <<< "$action"
         fi
       else
         echo >&2 " - take it (no proviso)."


### PR DESCRIPTION
This allows a situation where a job is required for a PR merge to still pass if they are skipped as per the documentation here: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks

BREAKING CHANGE: a new job conditional will be required
```
if: matrix.target.skipped == true
```
Otherwise the job will still run. This allows GitHub to properly update the status of the job without actually having to run it.